### PR TITLE
Refresh fellowship tables with 2024-2025 deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,70 +6,71 @@ A curated list of fellowships and scholarships for graduate students in Computer
 
 The best way to receive funding is through your respective graduate programs. Most reputable PhD programs provide full funding through a teaching assistantship (TA), research assistantship (RA), or university fellowship. ProFellow has a great list of fully-funded PhD programs in Computer Science [here](https://www.profellow.com/fellowships/fully-funded-phd-programs-in-computer-science/). As you progress throughout your programs, you may find additional sources of funding helpful to travel to conferences, focus on your research without teaching commitments, or to upgrade your equipment. Definitely take advantage of these opportunities below by applying to scholarships and/or fellowships:
 
+_Last updated September 2025. Deadlines were verified against official calls and the [CMU School of Computer Science graduate fellowship data feed](https://www.cs.cmu.edu/rs-datasources/data-source/grad-fellowships). Dates marked with * reflect the most recent published cycle and may shift—always confirm on the program website before applying._
 
-## Awards
-| Name          | Deadline      | Masters/PhD  |
-| ------------- |:-------------:| ------------:|
-| [ACM SIGAI Doctoral Dissertation Award](https://awards.acm.org/doctoral-dissertation/nominations) | October | PhD |
-| [Nature Research Awards for Inspiring and Innovating Science](https://www.nature.com/collections/jcpghfmqlz/applynow?utm_source=twitter&utm_medium=social&utm_campaign=awds-esteelauder2020&utm_content=organic) | June | Post-PhD |
-| [Rising Stars in Machine Learning](https://ml.umd.edu/rising-stars) | August | PhD |
+## Awards & Recognition
+| Name | 2025 Application Window | Eligible Stage | Notes |
+| --- | --- | --- | --- |
+| [ACM SIGAI Doctoral Dissertation Award](https://awards.acm.org/doctoral-dissertation/nominations) | TBD (historically opens in spring) | Ph.D. graduates | Recognizes the top doctoral dissertation in AI; requires a nomination from the degree-granting department. |
+| [Nature Awards for Inspiring Women in Science](https://www.nature.com/immersive/inspiringwomeninscience/) | Applications open 15 Jan 2025, close 9 Apr 2025 | Post-PhD / STEM outreach teams | Honors scientists and outreach champions advancing women in STEM; winners announced 15 Oct 2025. |
+| [Siebel Scholars Program](http://www.siebelscholars.com/) | July 16, 2025 | Final-year master's & Ph.D. students at partner universities | University-nominated recognition providing $25K toward tuition and a $10K cash award. |
 
-## Scholarships
-| Name          | Deadline      | Masters/PhD  |
-| ------------- |:-------------:| ------------:|
-| [Generation Google Scholarship](https://buildyourfuture.withgoogle.com/scholarships/generation-google-scholarship/#!?detail-content-tabby_activeEl=overview) | December | Both |
-| [Google Women Techmakers Scholarship](https://www.womentechmakers.com/scholars) | December | Both |
-| [Intel Scholarship](https://scholarships.uncf.org/Program/Details/9eb15008-3567-45ed-b62f-aa14c784b09a) | December | Both |
-| [NANOG Scholarship](https://www.nanog.org/outreach/scholarship-program/) | Varies | Both |
-| [National Society of Black Engineers](https://connect.nsbe.org/Scholarships/ScholarshipList.aspx) | Varies | Both |
-| [Oracle Academy](https://academy.oracle.com/en/about-scholarships.html) | Varies | Both |
-| [Society of Women Engineers](https://societyofwomenengineers.swe.org/swe-scholarships) | Varies | Both|
-| |  |  |
-| |  |  | 
+## Scholarships (2024-2025 cycle)
+The scholarships below list the most recent deadline announced as of 2024–2025. Confirm exact dates on the official websites because many programs refresh their portals annually.
+
+| Name | Next Deadline | Level | Eligibility Highlights | Typical Award |
+| --- | --- | --- | --- | --- |
+| [Korean American Scholarship Foundation](https://www.kasf.org/scholarships/) | June 30, 2024 | M.S. & Ph.D. | Korean American students (including foreign students from Korea); some funds available for descendants of Korean War veterans. | $500–$5,000 |
+| [NSERC Postgraduate Scholarships – Doctoral (PGS D)](https://www.nserc-crsng.gc.ca/Students-Etudiants/PG-CS/BellandPostgrad-BelletSuperieures_eng.asp) | October 17, 2024 | Ph.D. | Canadian citizens or permanent residents within the first 24 months of their PhD (36 months without a master's). | $21,000 per year for three years |
+| [Croucher Scholarships for Doctoral Study](https://croucher.org.hk/en/scholarships-scholarships) | November 15, 2024 | Ph.D. | Hong Kong permanent residents with first-class honors pursuing doctoral study in science, technology, engineering, or medicine. | Tuition plus stipends up to HK$304,800 (~US$38,850) annually |
+| [ARCS Foundation Pittsburgh Scholars](https://www.arcspittsburgh.org/) | February 8, 2024 | Ph.D. | STEM PhD students at Pittsburgh-area partner universities (Carnegie Mellon and University of Pittsburgh). | $5,000 per year for up to three years |
+| [Laura Bassi Scholarship](https://editing.press/bassi) | March 24, 2024 | M.S. & Ph.D. | Graduate researchers needing editorial assistance for projects with limited access to institutional resources. | Up to $750 (master's) or $2,500 (PhD) in editing support |
 
 
-## Fellowships 
-| Name          | Deadline      | Masters/PhD  | Citizenship  | Nomination   |
-| ------------- |:-------------:| ------------:| ------------:| ------------:|
-| [AAUW American Fellowships](https://www.aauw.org/what-we-do/educational-funding-and-awards/american-fellowships/) | November | PhD |  |  |
-| [ACM SIGHPC / Intel Computational & Data Science Fellowship](https://www.sighpc.org/fellowships) | April | Both |  |  |
-| [ACM-IEEE CS George Michael Memorial HPC Fellowship](https://awards.acm.org/hpc-fellows) | May | PhD |  |  |
-| [Adobe Fellowship](https://research.adobe.com/fellowship/) | September | Both |  |  |
-| [Bloomberg Data Science Fellowship](https://www.techatbloomberg.com/bloomberg-data-science-ph-d-fellowship/) | April | PhD |  |  |
-| [Computing Innovation Fellows (CIFellows) Program](https://cra.org/ccc/leadership-development/cifellows/) | TBD | Post-PhD |  |  |
-| [Congressional Innovation Scholars Program](https://www.techcongress.io/blog/2019/2/7/now-recruiting-2019-congressional-innovation-scholars) | February | PhD |  |  |
-| Datminr Diversity in AI for Good Fellowship | December | PhD |  |  |
-| [DOE Computational Science Graduate Fellowship](https://www.krellinst.org/csgf/) | January | PhD |  |  |
-| [Facebook Fellowship Program and Emerging Scholar Awards](https://research.fb.com/programs/fellowship/) | October | PhD |  |  |
-| [Ford Foundation Fellowship Program](http://sites.nationalacademies.org/pga/fordfellowships/index.htm) | January | PhD |  |  |
-| [GEM Fellowship Program](http://www.gemfellowship.org/) | November | Both |  |  |
-| [Google PhD Fellowship](https://ai.google/research/outreach/phd-fellowship/) | December | PhD |  |  |
-| [Hertz Fellowship](https://hertzfoundation.org/fellowships/application/) | October | PhD |  |  |
-| [HRT Hail Fellowship](http://www.hudson-trading.com/fellowship/) | December | PhD |  |  |
-| [IBM Masters Fellowship](https://www.research.ibm.com/university/awards/masters_fellowship.html) | October | Masters |  |  |
-| [IBM Ph.D. Fellowship](https://www.research.ibm.com/university/awards/fellowships.html) | October | PhD |  |  |
-| [Link Foundation Fellowship](http://www.linksim.org) | January | PhD |  |  |
-| [Microsoft Ada Lovelace Fellowship](https://www.microsoft.com/en-us/research/academic-program/ada-lovelace-fellowship/) | September | PhD |  |  |
-| [Microsoft Research PhD Fellowship Program](https://www.microsoft.com/en-us/research/academic-program/phd-fellowship/) | September | PhD |  |  |
-| [National Defense Science and Engineering Graduate Fellowship](https://www.ndsegfellowships.org/application) | December | PhD |  |  |
-| [NPSC Fellowship](http://www.npsc.org/index.html)| December | Both |  |  |
-| [NVIDIA Fellowship](https://www.nvidia.com/en-us/research/graduate-fellowships/)| September | PhD |  |  |
-| [NSF Graduate Research Fellowship](https://www.nsfgrfp.org/) | October | Both |  |  |
-| [Open Phil AI Fellowship](https://www.openphilanthropy.org/focus/global-catastrophic-risks/potential-risks-advanced-artificial-intelligence/the-open-phil-ai-fellowship) | October | PhD |  |  |
-| [Paul & Daisy Soros Fellowships for New Americans](https://www.pdsoros.org/) | November | Both |  |  |
-| [PEO Scholar Award](https://www.peointernational.org/psa-eligibility-requirements) | November | PhD |  |  |
-| [Qualcomm Innovation Fellowship](https://www.qualcomm.com/invention/research/university-relations/innovation-fellowship) | October | PhD |  |  |
-| [SCGSR Program](http://science.energy.gov/wdts/scgsr/) | May | PhD |  |  |
-| [Schlumberger Foundation Faculty for the Future Fellowship](https://www.fftf.slb.com/) | November | PhD |  |  |
-| [Siebel Scholars](http://www.siebelscholars.com/about) (Open to select schools) | July | PhD |  |  |
-| [SMART Scholarship for Service Program](https://smartscholarshipprod.service-now.com/smart) | December | Both |  |  |
-| [Snap Research Fellowship & Scholarship Program](https://snapresearchfs.splashthat.com/) | December | PhD |  |  |
-| [Symantec Research Labs Graduate Fellowship](https://www.symantec.com/about/careers/graduate-fellowship) | December | PhD |  |  |
-| [Twitter PhD Research Fellowship](https://phdfellowship.splashthat.com/) | December | PhD |  |  |
-| [Two Sigma PhD Fellowship](https://twosigma.avature.net/eventsignup/eventDetail/New-York-New-York-United-States-2021-Two-Sigma-PhD-Fellowship/7272) | November | PhD |  |  |
-| [Two Sigma Diversity PhD Fellowship](https://twosigma.avature.net/eventsignup/eventDetail/New-York-New-York-United-States-2021-Two-Sigma-Diversity-PhD-Fellowship/7273) | November | PhD |  |  |
-|               |               |              |               |              |
+## Fellowships
+### Government & Foundation Fellowships
+| Name | Next Deadline | Level | Eligibility Highlights | Notes |
+| --- | --- | --- | --- | --- |
+| [NSF Graduate Research Fellowship (GRFP)](https://new.nsf.gov/funding/opportunities/nsf-graduate-research-fellowship-program-grfp) | Oct 27–30, 2025 (field-specific) | M.S. & Ph.D. | U.S. citizens or permanent residents in early graduate study; up to one prior year of graduate enrollment. | No nomination; CISE proposals are due 28 Oct 2025 and other fields follow on adjacent days. |
+| [Hertz Fellowship](https://www.hertzfoundation.org/apply/) | October 31, 2025 | Ph.D. | U.S. citizens or permanent residents who are college seniors or first-year graduate students in applied physical, biological, or engineering sciences. | Application opens 28 Aug 2025; finalists notified Feb 2026 and recipients announced May 2026. |
+| [NDSEG Fellowship](http://ndseg.sysplus.com/NDSEG/Applicants/How-to-Apply) | November 1, 2024 | Ph.D. | U.S. citizens or nationals in the first two years of graduate study with at least three years remaining in a STEM PhD. | Three-year Department of Defense fellowship covering tuition, $43,200 stipend, and travel support. |
+| [DoD SMART Scholarship-for-Service](https://www.smartscholarship.org/smart) | December 1, 2024* | M.S. & Ph.D. | Citizens of the U.S., Australia, Canada, New Zealand, or United Kingdom willing to accept a DoD service commitment. | Covers full tuition and fees, provides a yearly stipend, and includes post-graduation employment at a DoD facility. |
+| [GEM Fellowship Program](https://www.gemfellowship.org/gem-fellowship-program/) | November 15, 2024* | M.S. & Ph.D. | U.S. citizens or permanent residents from groups underrepresented in STEM who apply to at least three GEM member universities. | Combines graduate tuition support with paid summer internships at partner companies. |
+| [Paul & Daisy Soros Fellowships for New Americans](https://www.pdsoros.org/) | October 31, 2024 | M.S. & Ph.D. | Immigrants and children of immigrants pursuing graduate study in the United States. | Provides up to $90,000 over two years for tuition and living expenses. |
+| [Quad Fellowship](https://www.quadfellowship.org/) | March 3, 2025 | M.S. & Ph.D. | Citizens or legal permanent residents of Australia, India, Japan, or the U.S. pursuing STEM graduate degrees at U.S. universities. | $50,000 scholarship plus cross-country leadership programming and mentorship. |
+| [US DOE Computational Science Graduate Fellowship (CSGF)](https://www.krellinst.org/csgf/about-doe-csgf) | January 17, 2024 | M.S. & Ph.D. | U.S. citizens or permanent residents entering or in their first year of graduate study in computational science or engineering. | Four-year package with tuition, annual stipend, and a practicum at a Department of Energy laboratory. |
+| [Graduate Fellowships for STEM Diversity (GFSD)](https://stemfellowships.org/) | January 7, 2024 | M.S. & Ph.D. | U.S. citizens pursuing advanced STEM degrees at any stage of their program. | Fellowship includes tuition, stipend, and paid DoD summer research internships. |
+| [Link Foundation Modeling, Simulation, and Training Fellowship](https://linksim.org/) | January 29, 2024 | Ph.D. | PhD students conducting research in modeling, simulation, and training with at least one year remaining. | Supports dissertation research with a multi-year stipend and travel funding. |
 
+### Corporate & Lab Fellowships
+| Name | Next Deadline | Level | Eligibility Highlights | Notes |
+| --- | --- | --- | --- | --- |
+| [Apple PhD fellowship in AI/ML](https://machinelearning.apple.com/updates/apple-scholars-aiml-2024) | September 9, 2025 | Ph.D. | Third- and fourth-year PhD students advancing Apple’s current AI/ML focus areas. | Requires institutional nomination; CMU’s internal deadline is 25 Jul 2025 with department deadlines earlier. |
+| [Google PhD Fellowship](https://research.google/programs-and-events/phd-fellowship/) | May 15, 2025 | Ph.D. | PhD students who have completed coursework and conduct research in Google’s priority areas. | University nomination required; CMU submits nominees by 11 Apr 2025. |
+| [NVIDIA Graduate Fellowship](https://www.nvidia.com/en-us/research/graduate-fellowships/) | September 13, 2024 | Ph.D. | Students who have finished at least one year of PhD study in CS, CE, EE, systems, or related areas. | Provides $60,000 and mentorship; recommendation letters are due 11 Sep 2024 at 3 p.m. Pacific Time. |
+| [IBM PhD Fellowship](https://research.ibm.com/university/awards/fellowships.html) | August 24, 2024* | Ph.D. | PhD students with at least two academic years remaining whose work aligns with IBM research priorities. | Nomination-driven; CMU runs an SCS-wide selection process once IBM announces the annual call. |
+| [Qualcomm Innovation Fellowship](https://www.qualcomm.com/research/university-relations/innovation-fellowship) | December 2, 2024 | Ph.D. | Teams of two PhD students at select universities propose cutting-edge research projects. | Limited to partner institutions; verify internal nomination rules before applying. |
+| [Two Sigma PhD Fellowship](https://www.twosigma.com/community/academic-partnerships/graduate-students/phd-fellowships/) | November 6, 2024 | Ph.D. | Third- or fourth-year PhD students in quantitative disciplines (CS, math, statistics, physics, etc.). | Offers a stipend and optional internship; review the program page for current benefits. |
+| [Jane Street Graduate Research Fellowship](https://www.janestreet.com/join-jane-street/programs-and-events/graduate-research-fellowship/) | November 21, 2024 | Ph.D. | PhD students in their 2nd–6th year studying math, computer science, physics, or statistics. | Provides a stipend and mentorship from Jane Street researchers; no nomination required. |
+| [J.P. Morgan PhD Fellowship](https://www.jpmorgan.com/technology/artificial-intelligence/research-awards) | March 31, 2024 | Ph.D. | Third- or fourth-year PhD students tackling AI, data science, cryptography, or quantitative finance topics. | Faculty nomination required; fellows receive funding and access to research collaborations. |
+| [Meta Research PhD Fellowship](https://www.metacareers.com/v2/jobs/304954532512788/) | February 21, 2024 | Ph.D. | Full-time PhD students working in Meta research focus areas (AI, AR/VR, privacy, etc.). | 2024 fellows were announced under this program; Meta is refreshing the structure for future cycles—watch the program page for updates. |
+| [MongoDB PhD Fellowship Program](https://www.mongodb.com/academia/phd-fellowship) | October 31, 2024 | Ph.D. | PhD candidates researching database systems, distributed systems, or developer tooling. | Fellows receive financial support and mentorship from MongoDB researchers. |
+| [Microsoft Research PhD Fellowship](https://www.microsoft.com/en-us/research/academic-program/phd-fellowship/) | Program on hold (last deadline May 1, 2024) | Ph.D. | Historically for third-year PhD students doing computer science research. | Microsoft is redesigning the fellowship program; check the site for the relaunch announcement. |
+| [Novartis Data Science Innovation Fellowship Program](https://www.novartis.com/careers/career-search?search_api_fulltext=%23DSIF&form_id=search_listing_filter_form&op=Submit) | July 29, 2024 | Postdoctoral | Final-year PhD students pursuing applied data science who are interested in an industry postdoc. | Two-year postdoctoral fellowship based in the Novartis Institutes for BioMedical Research. |
+
+### High-Performance Computing & Cyberinfrastructure
+| Name | Next Deadline | Level | Eligibility Highlights | Notes |
+| --- | --- | --- | --- | --- |
+| [ACM-IEEE CS George Michael Memorial HPC Fellowships](https://awards.acm.org/hpc-fellows) | May 1, 2024 | Ph.D. | PhD students advancing high-performance computing applications, networking, storage, or large-scale data analytics. | Recognizes two outstanding students annually with a $5,000 honorarium and SC Conference travel support. |
+| [NSF/TACC Frontera Computational Science Fellowship](https://frontera-portal.tacc.utexas.edu/fellowship/) | February 6, 2024 | Ph.D. | PhD students with at least one year remaining who rely on the Frontera supercomputer for computational research. | Provides a $30,000 stipend, allocation on Frontera, and funding for conferences and travel. |
+
+### Postdoctoral & Institution-Specific Opportunities
+| Name | Next Deadline | Level | Eligibility Highlights | Notes |
+| --- | --- | --- | --- | --- |
+| [Naval Research Laboratory Postdoctoral Fellowship Program](http://nrl.asee.org/) | September 1, 2024 | Postdoctoral | U.S. citizens or permanent residents completing PhDs in science or engineering fields relevant to naval research. | Two- and three-year fellowships with competitive salaries, relocation support, and access to NRL facilities. |
+| [Sandia National Labs Postdoctoral Fellowships](https://www.sandia.gov/careers/career-possibilities/students-and-postdocs/fellowships/) | September 12, 2024 | Postdoctoral | New PhDs in engineering, computation, or science disciplines interested in national security research. | Multiple named fellowships offering generous salary, benefits, and potential for permanent positions. |
+| [Center for Machine Learning and Health Fellowships in Digital Health Innovation](https://www.cs.cmu.edu/cmlh/fellowships-digital-health) | April 2, 2024 | Ph.D. (CMU) | Carnegie Mellon PhD students pursuing translational research in digital health. | Provides stipend supplements, mentorship, and access to healthcare partners to accelerate deployment. |
+| [CMU Rales Fellowship](https://www.cmu.edu/graduate/rales-fellows/) | December 15, 2024 | M.S. & Ph.D. (CMU) | STEM graduate students from under-resourced backgrounds enrolling at Carnegie Mellon University. | Comprehensive funding covering tuition, stipend, and cohort-based professional development. |
 ## Fellowship Specific Resources
 
 ### Facebook Fellowship Program and Emerging Scholar Awards


### PR DESCRIPTION
## Summary
- add a 2025 update notice referencing the CMU SCS fellowship data feed
- refresh the awards table with current windows for ACM SIGAI, Nature Awards, and Siebel Scholars
- rebuild the scholarships and fellowships sections with 2024-2025 deadlines, eligibility notes, and nomination details, including corporate, government, HPC, and institutional programs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd746dfccc8322bb492d45e656f2e0